### PR TITLE
Solve double printing

### DIFF
--- a/pandoc_run_python/filter.py
+++ b/pandoc_run_python/filter.py
@@ -102,6 +102,10 @@ def action(elem: pf.Element, doc: pf.Doc) -> list:
             for fig in eval_output.fc.figures:
                 collector.append(elements.Para(elements.Image(url=str(fig))))
 
+        # flag to delete original code from markdown - only the results remain
+        if "del" in elem.classes:
+            collector.remove(elem)
+
         return collector
     # remove previously generated output
     elif isinstance(elem, pf.CodeBlock) and "python-output" in elem.classes:

--- a/pandoc_run_python/mpl_backend.py
+++ b/pandoc_run_python/mpl_backend.py
@@ -34,8 +34,8 @@ def show(*args: list, **kwargs: dict) -> FigureContainer:
     for num, figmanager in enumerate(Gcf.get_all_fig_managers()):
         fn = (
             pathlib.Path(FIGURES_DIR, f"figure_{id}_{num}.png")
-            .resolve()
-            .relative_to(pathlib.Path.cwd())
+                .resolve()
+                .relative_to(pathlib.Path.cwd())
         )
         figmanager.canvas.figure.savefig(fn)
         fc.figures.append(fn)

--- a/tests/sample_files/github_example.md
+++ b/tests/sample_files/github_example.md
@@ -1,0 +1,5 @@
+## What is fast, loud and crunchy?
+
+``` {.python .run}
+print("A rocket chip!")
+```

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -1,7 +1,6 @@
 import panflute as pf
 from pathlib import Path
 from pandoc_run_python import filter
-import io
 
 
 def doc_loader(fn: str) -> str:
@@ -18,6 +17,24 @@ def test_basic():
         doc_altered, input_format="panflute", output_format="markdown"
     )
     assert "``` {.python-output}" in md_altered
+
+
+def test_github_example():
+    doc = doc_loader("github_example.md")
+    doc_altered = filter.main(doc)
+    md_altered = pf.convert_text(
+        doc_altered, input_format="panflute", output_format="markdown"
+    )
+    assert md_altered == """## What is fast, loud and crunchy?
+
+``` {.python .run .black-d}
+print("A rocket chip!")
+```
+
+``` {.python-output}
+A rocket chip!
+```"""
+
 
 def test_wellea():
     doc = doc_loader("simple_wellea.md")
@@ -38,6 +55,7 @@ def test_replace_old_output():
     assert "``` {.python-output}" in md_altered
     assert "WILL BE REPLACED" not in md_altered
 
+
 def test_eval_last_value():
     doc = doc_loader("eval_last.md")
     doc_altered = filter.main(doc)
@@ -47,6 +65,7 @@ def test_eval_last_value():
     assert """``` {.python-output}
 3
 ```""" in md_altered
+
 
 def test_eval_no_output():
     doc = doc_loader("no_output.md")

--- a/tests/test_formatter.py
+++ b/tests/test_formatter.py
@@ -1,7 +1,6 @@
 from pandoc_run_python.filter import code_formatter
 
 
-
 def test_formatter():
     as_is = """
     a = {1:0,

--- a/tests/test_matplotlib.py
+++ b/tests/test_matplotlib.py
@@ -1,7 +1,6 @@
 import panflute as pf
 from pathlib import Path
 from pandoc_run_python import filter
-import io
 
 
 def doc_loader(fn: str) -> str:
@@ -18,4 +17,3 @@ def test_image_insert():
         doc_altered, input_format="panflute", output_format="markdown"
     )
     assert "![](figures/" in md_altered
-


### PR DESCRIPTION
I had an issue where tests failed due to output formatting. This has a (hacky) solve to avoid double printing output when there is a `print()` statement in the `final_line`.

Also, it's helpful to add a .del flag like

``` 
""" {.python .run .del}
print("A rocket chip!")
"""
```

To preserve only the code output. Hopefully this is helpful to others.
